### PR TITLE
Remove rollup-plugin-copy keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "copy",
     "assets",
     "copier",
-    "rollup-plugin-copier",
-    "rollup-plugin-copy"
+    "rollup-plugin-copier"
   ],
   "author": "Marek Sierociński <mareksierocinski@gmail.com>",
   "license": "ISC",


### PR DESCRIPTION
Really? Another package name in package keywords?